### PR TITLE
Test create-empty-github-release entrypoint

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -15,20 +15,20 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Release notes
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: publish-release-notes-to-github
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: Zulip
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: send-announcement-to-pony-zulip
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_RELEASE_API_KEY }}
           ZULIP_EMAIL: ${{ secrets.ZULIP_RELEASE_EMAIL }}
       - name: Last Week in Pony
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: add-announcement-to-last-week-in-pony
         env:
@@ -46,14 +46,14 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Rotate release notes
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: rotate-release-notes
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
       - name: Delete announcement trigger tag
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: delete-announcement-tag
         env:

--- a/.github/workflows/prepare-for-a-release.yml
+++ b/.github/workflows/prepare-for-a-release.yml
@@ -18,35 +18,35 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Set action to run using prebuilt image
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: update-action-to-use-docker-image-to-run-action
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
       - name: Update version in README
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: update-version-in-README
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
       - name: Update CHANGELOG.md
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: update-changelog-for-release
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
       - name: Update VERSION
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: update-version-in-VERSION
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
       - name: Update corral.json
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: update-version-in-corral-json
         env:
@@ -68,7 +68,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Trigger artefact creation
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: trigger-artefact-creation
         env:
@@ -93,14 +93,14 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Add "unreleased" section to CHANGELOG.md
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: add-unreleased-section-to-changelog
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
       - name: Set action to run using Dockerfile
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: update-action-to-use-dockerfile-to-run-action
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,15 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Validate CHANGELOG
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: pre-artefact-changelog-check
+      - name: Create empty GitHub release
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
+        with:
+          entrypoint: create-empty-github-release
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
   build-library-documentation:
     runs-on: ubuntu-latest
@@ -70,7 +76,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Trigger
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: ponylang/release-bot-action@create-empty-github-release-entrypoint
         with:
           entrypoint: trigger-release-announcement
         env:


### PR DESCRIPTION
Switches release-bot-action references to the `create-empty-github-release-entrypoint` branch and adds a `create-empty-github-release` step to the release workflow's `pre-artefact-creation` job to exercise the new entrypoint.