### PR TITLE
Use library-documentation-action-v2 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  packages: read
 
 concurrency:
   group: "update-documentation"
@@ -50,7 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Generate documentation
-        uses: ponylang/library-documentation-action@via-github-action
+        uses: docker://ghcr.io/ponylang/library-documentation-action-v2:release
         with:
           site_url: "https://ponylang.github.io/action-testing/"
           library_name: "http"


### PR DESCRIPTION
Switches the release workflow's documentation step from the old `library-documentation-action@via-github-action` branch reference to the prebuilt `library-documentation-action-v2:release` image, matching the v2 README and the pattern already used in `generate-documentation.yml`.