### PR TITLE
Add pony-lint CI and fix all lint errors

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 BUILD_DOCS_WITH := corral run -- pony-doc
+LINT_WITH := corral run -- pony-lint
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR := $(PACKAGE)
@@ -42,7 +43,11 @@ $(docs_dir): $(BUILD_DIR) $(SOURCE_FILES)
 
 docs: $(docs_dir)
 
+lint:
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) .
+
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: build pylint push
+.PHONY: build pylint push lint

--- a/http/_client_conn_handler.pony
+++ b/http/_client_conn_handler.pony
@@ -44,13 +44,16 @@ class _ClientConnHandler is TCPConnectionNotify
     """
     _session._auth_failed(conn)
 
-  fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
-    times: USize): Bool
+  fun ref received(
+    conn: TCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
   =>
-   """
-   Pass a received chunk of data to the `HTTPParser`.
-   """
-   // TODO: inactivity timer
+    """
+    Pass a received chunk of data to the `HTTPParser`.
+    """
+    // TODO: inactivity timer
     _buffer.append(consume data)
 
     // Let the parser take a look at what has been received.

--- a/http/_client_connection.pony
+++ b/http/_client_connection.pony
@@ -303,13 +303,17 @@ actor _ClientConnection is HTTPSession
         let ssl = ctx.client(_host)?
         TCPConnection(
           _auth,
-          SSLConnection(_ClientConnHandler(this, _keepalive_timeout_secs), consume ssl),
-          _host, _service)
+          SSLConnection(
+            _ClientConnHandler(this, _keepalive_timeout_secs),
+            consume ssl),
+          _host,
+          _service)
       else
         TCPConnection(
           _auth,
           _ClientConnHandler(this, _keepalive_timeout_secs),
-          _host, _service)
+          _host,
+          _service)
       end
       _conn = _ConnConnecting
     end

--- a/http/_test.pony
+++ b/http/_test.pony
@@ -44,8 +44,10 @@ class \nodoc\ iso _Encode is UnitTest
 
   fun apply(h: TestHelper) ? =>
     // Unreserved chars, decoded.
-    h.assert_eq[String]("Aa4-._~Aa4-._~",
-      URLEncode.encode("Aa4-._~%41%61%34%2D%2E%5F%7E", URLPartUser)?)
+    h.assert_eq[String](
+      "Aa4-._~Aa4-._~",
+      URLEncode.encode(
+        "Aa4-._~%41%61%34%2D%2E%5F%7E", URLPartUser)?)
 
     h.assert_eq[String]("F_12x", URLEncode.encode("F_1%32x", URLPartPassword)?)
     h.assert_eq[String]("F_12x", URLEncode.encode("F_1%32x", URLPartHost)?)
@@ -54,8 +56,10 @@ class \nodoc\ iso _Encode is UnitTest
     h.assert_eq[String]("F_12x", URLEncode.encode("F_1%32x", URLPartFragment)?)
 
     // Sub-delimiters, left encoded or not as original.
-    h.assert_eq[String]("!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D",
-      URLEncode.encode("!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D",
+    h.assert_eq[String](
+      "!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D",
+      URLEncode.encode(
+        "!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D",
         URLPartUser)?)
 
     h.assert_eq[String](",%2C", URLEncode.encode(",%2C", URLPartPassword)?)
@@ -65,9 +69,11 @@ class \nodoc\ iso _Encode is UnitTest
     h.assert_eq[String](",%2C", URLEncode.encode(",%2C", URLPartFragment)?)
 
     // Misc characters, encoded.
-    h.assert_eq[String]("%23%3C%3E%5B%5D%7B%7D%7C%5E%20" +
-      "%23%3C%3E%5B%5D%7B%7D%7C%5E%25",
-      URLEncode.encode("#<>[]{}|^ %23%3C%3E%5B%5D%7B%7D%7C%5E%25",
+    h.assert_eq[String](
+      "%23%3C%3E%5B%5D%7B%7D%7C%5E%20"
+        + "%23%3C%3E%5B%5D%7B%7D%7C%5E%25",
+      URLEncode.encode(
+        "#<>[]{}|^ %23%3C%3E%5B%5D%7B%7D%7C%5E%25",
         URLPartUser)?)
 
     h.assert_eq[String]("%23%23", URLEncode.encode("#%23", URLPartPassword)?)
@@ -78,7 +84,8 @@ class \nodoc\ iso _Encode is UnitTest
 
     // Delimiters, whether encoded depends on URL part.
     h.assert_eq[String]("%3A%40%2F%3F", URLEncode.encode(":@/?", URLPartUser)?)
-    h.assert_eq[String](":%40%2F%3F",
+    h.assert_eq[String](
+      ":%40%2F%3F",
       URLEncode.encode(":@/?", URLPartPassword)?)
     h.assert_eq[String]("%3A%40%2F%3F", URLEncode.encode(":@/?", URLPartHost)?)
     h.assert_eq[String](":@/%3F", URLEncode.encode(":@/?", URLPartPath)?)
@@ -120,8 +127,10 @@ class \nodoc\ iso _Check is UnitTest
 
   fun apply(h: TestHelper) =>
     // Unreserved chars, legal encoded or not.
-    h.assert_eq[Bool](true,
-      URLEncode.check("Aa4-._~%41%61%34%2D%2E%5F%7E", URLPartUser))
+    h.assert_eq[Bool](
+      true,
+      URLEncode.check(
+        "Aa4-._~%41%61%34%2D%2E%5F%7E", URLPartUser))
 
     h.assert_eq[Bool](true, URLEncode.check("F_1%32x", URLPartPassword))
     h.assert_eq[Bool](true, URLEncode.check("F_1%32x", URLPartHost))
@@ -130,8 +139,10 @@ class \nodoc\ iso _Check is UnitTest
     h.assert_eq[Bool](true, URLEncode.check("F_1%32x", URLPartFragment))
 
     // Sub-delimiters, legal encoded or not.
-    h.assert_eq[Bool](true,
-      URLEncode.check("!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D",
+    h.assert_eq[Bool](
+      true,
+      URLEncode.check(
+        "!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D",
         URLPartUser))
 
     h.assert_eq[Bool](true, URLEncode.check(",%2C", URLPartPassword))
@@ -141,8 +152,10 @@ class \nodoc\ iso _Check is UnitTest
     h.assert_eq[Bool](true, URLEncode.check(",%2C", URLPartFragment))
 
     // Misc characters, must be encoded.
-    h.assert_eq[Bool](true,
-      URLEncode.check("%23%3C%3E%5B%5D%7B%7D%7C%5E%25", URLPartUser))
+    h.assert_eq[Bool](
+      true,
+      URLEncode.check(
+        "%23%3C%3E%5B%5D%7B%7D%7C%5E%25", URLPartUser))
     h.assert_eq[Bool](false, URLEncode.check("<", URLPartUser))
     h.assert_eq[Bool](false, URLEncode.check(">", URLPartUser))
     h.assert_eq[Bool](false, URLEncode.check("|", URLPartUser))
@@ -213,16 +226,21 @@ class \nodoc\ iso _Decode is UnitTest
   fun name(): String => "http/URLEncode.decode"
 
   fun apply(h: TestHelper) ? =>
-    h.assert_eq[String]("Aa4-._~Aa4-._~",
+    h.assert_eq[String](
+      "Aa4-._~Aa4-._~",
       URLEncode.decode("Aa4-._~%41%61%34%2D%2E%5F%7E")?)
 
     h.assert_eq[String]("F_12x", URLEncode.decode("F_1%32x")?)
 
-    h.assert_eq[String]("!$&'()* ,;=!$&'()*+,;=",
-      URLEncode.decode("!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D")?)
+    h.assert_eq[String](
+      "!$&'()* ,;=!$&'()*+,;=",
+      URLEncode.decode(
+        "!$&'()*+,;=%21%24%26%27%28%29%2A%2B%2C%3B%3D")?)
 
-    h.assert_eq[String]("#<>[]{}|^ #<>[]{}|^ %",
-      URLEncode.decode("#<>[]{}|^ %23%3C%3E%5B%5D%7B%7D%7C%5E%20%25")?)
+    h.assert_eq[String](
+      "#<>[]{}|^ #<>[]{}|^ %",
+      URLEncode.decode(
+        "#<>[]{}|^ %23%3C%3E%5B%5D%7B%7D%7C%5E%20%25")?)
 
 class \nodoc\ iso _DecodeBad is UnitTest
   fun name(): String => "http/URLEncode.decode_bad"
@@ -236,52 +254,161 @@ class \nodoc\ iso _BuildBasic is UnitTest
   fun name(): String => "http/URL.build_basic"
 
   fun apply(h: TestHelper) ? =>
-    _Test(h,
-      URL.build("https://user:password@host.name:12345/path?query#fragment")?,
-      "https", "user", "password", "host.name", 12345, "/path", "query",
+    _Test(
+      h,
+      URL.build(
+        "https://user:password@host.name:12345" +
+          "/path?query#fragment")?,
+      "https",
+      "user",
+      "password",
+      "host.name",
+      12345,
+      "/path",
+      "query",
       "fragment")
 
-    _Test(h,
-      URL.build("http://rosettacode.org/wiki/Category]Pony")?,
-      "http", "", "", "rosettacode.org", 80, "/wiki/Category%5DPony", "", "")
+    _Test(
+      h,
+      URL.build(
+        "http://rosettacode.org/wiki/Category]Pony")?,
+      "http",
+      "",
+      "",
+      "rosettacode.org",
+      80,
+      "/wiki/Category%5DPony",
+      "",
+      "")
 
-    _Test(h,
-      URL.build("https://en.wikipedia.org/wiki/Polymorphism_" +
-        "(computer_science)#Parametric_polymorphism")?,
-      "https", "", "", "en.wikipedia.org", 443,
-      "/wiki/Polymorphism_(computer_science)", "",
+    _Test(
+      h,
+      URL.build(
+        "https://en.wikipedia.org/wiki/Polymorphism_"
+          + "(computer_science)"
+          + "#Parametric_polymorphism")?,
+      "https",
+      "",
+      "",
+      "en.wikipedia.org",
+      443,
+      "/wiki/Polymorphism_(computer_science)",
+      "",
       "Parametric_polymorphism")
 
-    _Test(h, URL.build("http://user@host")?,
-      "http", "user", "", "host", 80, "/", "", "")
+    _Test(
+      h,
+      URL.build("http://user@host")?,
+      "http",
+      "user",
+      "",
+      "host",
+      80,
+      "/",
+      "",
+      "")
 
 class \nodoc\ iso _BuildMissingParts is UnitTest
   fun name(): String => "http/URL.build_missing_parts"
 
   fun apply(h: TestHelper) ? =>
-    _Test(h, URL.build("https://user@host.name/path#fragment")?,
-      "https", "user", "", "host.name", 443, "/path", "", "fragment")
+    _Test(
+      h,
+      URL.build(
+        "https://user@host.name/path#fragment")?,
+      "https",
+      "user",
+      "",
+      "host.name",
+      443,
+      "/path",
+      "",
+      "fragment")
 
-    _Test(h, URL.build("https://user@host.name#fragment")?,
-      "https", "user", "", "host.name", 443, "/", "", "fragment")
+    _Test(
+      h,
+      URL.build("https://user@host.name#fragment")?,
+      "https",
+      "user",
+      "",
+      "host.name",
+      443,
+      "/",
+      "",
+      "fragment")
 
-    _Test(h, URL.build("//host.name/path")?,
-      "", "", "", "host.name", 0, "/path", "", "")
+    _Test(
+      h,
+      URL.build("//host.name/path")?,
+      "",
+      "",
+      "",
+      "host.name",
+      0,
+      "/path",
+      "",
+      "")
 
-    _Test(h, URL.build("/path")?,
-      "", "", "", "", 0, "/path", "", "")
+    _Test(
+      h,
+      URL.build("/path")?,
+      "",
+      "",
+      "",
+      "",
+      0,
+      "/path",
+      "",
+      "")
 
-    _Test(h, URL.build("?query")?,
-      "", "", "", "", 0, "/", "query", "")
+    _Test(
+      h,
+      URL.build("?query")?,
+      "",
+      "",
+      "",
+      "",
+      0,
+      "/",
+      "query",
+      "")
 
-    _Test(h, URL.build("#fragment")?,
-      "", "", "", "", 0, "/", "", "fragment")
+    _Test(
+      h,
+      URL.build("#fragment")?,
+      "",
+      "",
+      "",
+      "",
+      0,
+      "/",
+      "",
+      "fragment")
 
-    _Test(h, URL.build("https://host.name/path#frag?ment")?,
-      "https", "", "", "host.name", 443, "/path", "", "frag?ment")
+    _Test(
+      h,
+      URL.build("https://host.name/path#frag?ment")?,
+      "https",
+      "",
+      "",
+      "host.name",
+      443,
+      "/path",
+      "",
+      "frag?ment")
 
-    _Test(h, URL.build("https://user@host.name?quer/y#fragment")?,
-      "https", "user", "", "host.name", 443, "/", "quer/y", "fragment")
+    _Test(
+      h,
+      URL.build(
+        "https://user@host.name?quer/y#fragment")?,
+      "https",
+      "user",
+      "",
+      "host.name",
+      443,
+      "/",
+      "quer/y",
+      "fragment")
 
 class \nodoc\ iso _BuildBad is UnitTest
   fun name(): String => "http/URL.build_bad"
@@ -311,29 +438,59 @@ class \nodoc\ iso _BuildNoEncoding is UnitTest
   fun name(): String => "http/URL.build_no_encoding"
 
   fun apply(h: TestHelper) ? =>
-    _Test(h, URL.build("https://host.name/path%32path", false)?,
-      "https", "", "", "host.name", 443, "/path%2532path", "", "")
+    _Test(
+      h,
+      URL.build(
+        "https://host.name/path%32path", false)?,
+      "https",
+      "",
+      "",
+      "host.name",
+      443,
+      "/path%2532path",
+      "",
+      "")
 
 class \nodoc\ iso _Valid is UnitTest
   fun name(): String => "http/URL.valid"
 
   fun apply(h: TestHelper) ? =>
-    _Test(h,
-      URL.valid("https://user:password@host.name:12345/path?query#fragment")?,
-      "https", "user", "password", "host.name", 12345, "/path", "query",
+    _Test(
+      h,
+      URL.valid(
+        "https://user:password@host.name:12345" +
+          "/path?query#fragment")?,
+      "https",
+      "user",
+      "password",
+      "host.name",
+      12345,
+      "/path",
+      "query",
       "fragment")
 
     h.assert_error({() ? =>
-      URL.valid("http://rosettacode.org/wiki/Category[Pony]")?
+      URL.valid(
+        "http://rosettacode.org/wiki/Category[Pony]")?
     })
 
     h.assert_error({() ? =>
-      URL.valid("https://en.wikipedia|org/wiki/Polymorphism_" +
-        "(computer_science)#Parametric_polymorphism")?
+      URL.valid(
+        "https://en.wikipedia|org/wiki/Polymorphism_"
+          + "(computer_science)#Parametric_polymorphism")?
     })
 
-    _Test(h, URL.valid("http://user@host")?,
-      "http", "user", "", "host", 80, "/", "", "")
+    _Test(
+      h,
+      URL.valid("http://user@host")?,
+      "http",
+      "user",
+      "",
+      "host",
+      80,
+      "/",
+      "",
+      "")
 
 class \nodoc\ iso _ToStringFun is UnitTest
   fun name(): String => "http/URL.to_string"
@@ -344,14 +501,18 @@ class \nodoc\ iso _ToStringFun is UnitTest
       URL.build("https://user:password@host.name:12345/path?query#fragment")?
         .string())
 
-    h.assert_eq[String]("http://rosettacode.org/wiki/Category%5DPony",
-      URL.build("http://rosettacode.org/wiki/Category]Pony")?.string())
+    h.assert_eq[String](
+      "http://rosettacode.org/wiki/Category%5DPony",
+      URL.build(
+        "http://rosettacode.org/wiki/Category]Pony")?.string())
 
-    h.assert_eq[String]("http://user@host/",
+    h.assert_eq[String](
+      "http://user@host/",
       URL.build("http://user@host")?.string())
 
     // Default ports should be omitted.
-    h.assert_eq[String]("http://host.name/path",
+    h.assert_eq[String](
+      "http://host.name/path",
       URL.build("http://host.name:80/path")?.string())
 
 primitive \nodoc\ _Test
@@ -420,7 +581,8 @@ class \nodoc\ iso _HTTPConnTest is UnitTest
     h.expect_action("server connection accepted")
     h.expect_action("server connection closed")
 
-    let worker = object
+    let worker =
+      object
       var client: (HTTPClient iso | None) = None
 
       be listening(service: String) =>
@@ -573,12 +735,12 @@ primitive \nodoc\ _FixedResponseHTTPServerNotify
               h.log("unthrottled")
           end // object
         end // recover
-
       end // object
     end // recover
 
 class \nodoc\ iso _HTTPParserNoBodyTest is UnitTest
   fun name(): String => "http/HTTPParser.NoBody"
+
   fun ref apply(h: TestHelper) =>
     let test_session =
       object is HTTPSession
@@ -603,14 +765,15 @@ class \nodoc\ iso _HTTPParserNoBodyTest is UnitTest
           h.fail("HTTPSession._finish called.")
       end
     let parser = HTTPParser.request(test_session)
-    let payload: String = "\r\n".join([
-      "GET /get HTTP/1.1"
-      "Host: httpbin.org"
-      "User-Agent: curl/7.58.0"
-      "Accept: */*"
-      ""
-      ""
-      ].values())
+    let payload: String =
+      "\r\n".join(
+        [ "GET /get HTTP/1.1"
+          "Host: httpbin.org"
+          "User-Agent: curl/7.58.0"
+          "Accept: */*"
+          ""
+          ""
+        ].values())
 
     h.long_test(2_000_000_000)
     h.expect_action("_deliver")
@@ -622,6 +785,7 @@ class \nodoc\ iso _HTTPParserNoBodyTest is UnitTest
 
 class \nodoc\ iso _HTTPParserOneshotBodyTest is UnitTest
   fun name(): String => "http/HTTPParser.OneshotBody"
+
   fun ref apply(h: TestHelper) =>
     let body = "custname=Pony+Mc+Ponyface&custtel=%2B490123456789&custemail=pony%40ponylang.org&size=large&topping=bacon&topping=cheese&topping=onion&delivery=&comments=This+is+a+stupid+test"
     let test_session =
@@ -655,22 +819,36 @@ class \nodoc\ iso _HTTPParserOneshotBodyTest is UnitTest
           h.fail("HTTPSession._finish called.")
       end
     let parser = HTTPParser.request(test_session)
-    let payload: String = "\r\n".join([
-        "POST /post HTTP/1.1"
-        "Host: httpbin.org"
-        "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
-        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-        "Accept-Language: en-GB,en;q=0.5"
-        "Accept-Encoding: gzip, deflate"
-        "Referer: http://httpbin.org/forms/post"
-        "Content-Type: application/x-www-form-urlencoded"
-        "Content-Length: 174"
-        "Cookie: _gauges_unique_hour=1; _gauges_unique_day=1; _gauges_unique_month=1; _gauges_unique_year=1; _gauges_unique=1"
-        "Connection: keep-alive"
-        "Upgrade-Insecure-Requests: 1"
-        ""
-        body
-      ].values())
+    let ua =
+      "User-Agent: Mozilla/5.0 (X11; Ubuntu;" +
+        " Linux x86_64; rv:61.0)" +
+        " Gecko/20100101 Firefox/61.0"
+    let accept =
+      "Accept: text/html,application/xhtml+xml" +
+        ",application/xml;q=0.9,*/*;q=0.8"
+    let cookie =
+      "Cookie: _gauges_unique_hour=1;" +
+        " _gauges_unique_day=1;" +
+        " _gauges_unique_month=1;" +
+        " _gauges_unique_year=1;" +
+        " _gauges_unique=1"
+    let payload: String =
+      "\r\n".join(
+        [ "POST /post HTTP/1.1"
+          "Host: httpbin.org"
+          ua
+          accept
+          "Accept-Language: en-GB,en;q=0.5"
+          "Accept-Encoding: gzip, deflate"
+          "Referer: http://httpbin.org/forms/post"
+          "Content-Type: application/x-www-form-urlencoded"
+          "Content-Length: 174"
+          cookie
+          "Connection: keep-alive"
+          "Upgrade-Insecure-Requests: 1"
+          ""
+          body
+        ].values())
     h.long_test(2_000_000_000)
     h.expect_action("_deliver")
     let reader: Reader = Reader
@@ -681,6 +859,7 @@ class \nodoc\ iso _HTTPParserOneshotBodyTest is UnitTest
 
 class \nodoc\ iso _HTTPParserStreamedBodyTest is UnitTest
   fun name(): String => "http/HTTPParser.StreamedBody"
+
   fun apply(h: TestHelper) =>
     let test_session =
       object is HTTPSession
@@ -699,13 +878,15 @@ class \nodoc\ iso _HTTPParserStreamedBodyTest is UnitTest
           h.complete_action("session._finish")
       end
     let parser = HTTPParser.response(test_session)
-    let payload: String = "\r\n".join([
-      "HTTP/1.1 200 OK"
-      "Content-Length: 10001"
-      "Content-Type: application/octet-stream"
-      ""
-      String.from_array(recover val Array[U8].init('a', 10001) end)
-    ].values())
+    let payload: String =
+      "\r\n".join(
+        [ "HTTP/1.1 200 OK"
+          "Content-Length: 10001"
+          "Content-Type: application/octet-stream"
+          ""
+          String.from_array(
+            recover val Array[U8].init('a', 10001) end)
+        ].values())
     h.long_test(2_000_000_000)
     h.expect_action("_deliver")
     h.expect_action("session._chunk")
@@ -717,7 +898,9 @@ class \nodoc\ iso _HTTPParserStreamedBodyTest is UnitTest
     end
 
 class \nodoc\ _PayloadHeadersAreCaseInsensitive is UnitTest
-  fun name(): String => "http/Payload.HeadersAreCaseInsensitive"
+  fun name(): String =>
+    "http/Payload.HeadersAreCaseInsensitive"
+
   fun apply(h: TestHelper) ? =>
     let url = URL.valid("https://example.com")?
     let request = Payload.request(where url' = url)

--- a/http/_test_client.pony
+++ b/http/_test_client.pony
@@ -12,6 +12,7 @@ class \nodoc\ val _StreamTransferHandlerFactory is HandlerFactory
   let _h: TestHelper
   var expected_length: USize = 0
   var received_size: USize = 0
+
   new val create(h: TestHelper) =>
     _h = h
 
@@ -41,6 +42,7 @@ class \nodoc\ val _StreamTransferHandlerFactory is HandlerFactory
 
 class \nodoc\ iso _ClientStreamTransferTest is UnitTest
   fun name(): String => "client/stream-transfer"
+
   fun apply(h: TestHelper) =>
     h.long_test(2_000_000_000)
 
@@ -50,20 +52,25 @@ class \nodoc\ iso _ClientStreamTransferTest is UnitTest
     h.expect_action("chunk")
     h.expect_action("finished")
 
-    let notify = object iso is TCPListenNotify
+    let notify =
+      object iso is TCPListenNotify
       let _h: TestHelper = h
 
       fun ref listening(listen: TCPListener ref) =>
         _h.complete_action("server listening")
         try
-          let client = HTTPClient(
-            TCPConnectAuth(_h.env.root),
-            None
-            where keepalive_timeout_secs = U32(2)
-          )
+          let client =
+            HTTPClient(
+              TCPConnectAuth(_h.env.root),
+              None
+              where keepalive_timeout_secs = U32(2)
+            )
           (let host, let port) = listen.local_address().name()?
           _h.log("connecting to server at " + host + ":" + port)
-          let req = Payload.request("GET", URL.build("http://" + host + ":" + port  + "/bla")?)
+          let url =
+            URL.build(
+              "http://" + host + ":" + port + "/bla")?
+          let req = Payload.request("GET", url)
           client(
             consume req,
             _StreamTransferHandlerFactory(_h)
@@ -82,11 +89,16 @@ class \nodoc\ iso _ClientStreamTransferTest is UnitTest
       fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
         object iso is TCPConnectionNotify
           var written: Bool = false
-          fun ref received(conn: TCPConnection ref, data: Array[U8] iso, times: USize): Bool =>
+          fun ref received(
+            conn: TCPConnection ref,
+            data: Array[U8] iso,
+            times: USize)
+            : Bool
+          =>
             _h.log("received stuff")
             if not written then
-              conn.write("\r\n".join([
-                "HTTP/1.1 200 OK"
+              conn.write("\r\n".join(
+                [ "HTTP/1.1 200 OK"
                 "Server: Bla"
                 "Content-Length: 10004"
                 "Content-Type: application/octet-stream"
@@ -116,5 +128,10 @@ class \nodoc\ iso _ClientStreamTransferTest is UnitTest
     let host = "127.0.0.1"
     let service = "0"
 
-    let listener = TCPListener.ip4(TCPListenAuth(h.env.root), consume notify, host, service)
+    let listener =
+      TCPListener.ip4(
+        TCPListenAuth(h.env.root),
+        consume notify,
+        host,
+        service)
     h.dispose_when_done(listener)

--- a/http/_test_client_error_handling.pony
+++ b/http/_test_client_error_handling.pony
@@ -18,6 +18,7 @@ actor \nodoc\ _ClientErrorHandlingTests is TestList
 
 class \nodoc\ val _ConnectionClosedHandlerFactory is HandlerFactory
   let _h: TestHelper
+
   new val create(h: TestHelper) =>
     _h = h
 
@@ -44,29 +45,37 @@ class \nodoc\ iso _ConnectionClosedTest is UnitTest
     h.expect_action("server connection closed")
     h.expect_action("client failed with ConnectionClosed")
 
-    let notify = object iso is TCPListenNotify
-      let _h: TestHelper = h
-      fun ref listening(listen: TCPListener ref) =>
-        _h.complete_action("server listening")
-        _h.log("listening")
+    let notify =
+      object iso is TCPListenNotify
+        let _h: TestHelper = h
 
-        try
-          let client = HTTPClient(
-            TCPConnectAuth(_h.env.root),
-            None
-            where keepalive_timeout_secs = U32(2)
-          )
-          (let host, let port) = listen.local_address().name()?
-          let req = Payload.request("GET",
-            URL.build("http://" + host + ":" + port  + "/bla")?)
-          req.add_chunk("CHUNK")
-          client(
-            consume req,
-            _ConnectionClosedHandlerFactory(_h)
-          )?
-        else
-          _h.fail("request building failed")
-        end
+        fun ref listening(listen: TCPListener ref) =>
+          _h.complete_action("server listening")
+          _h.log("listening")
+
+          try
+            let client =
+              HTTPClient(
+                TCPConnectAuth(_h.env.root),
+                None
+                where keepalive_timeout_secs = U32(2)
+              )
+            (let host, let port) =
+              listen.local_address().name()?
+            let req =
+              Payload.request(
+                "GET",
+                URL.build(
+                  "http://" + host + ":"
+                    + port + "/bla")?)
+            req.add_chunk("CHUNK")
+            client(
+              consume req,
+              _ConnectionClosedHandlerFactory(_h)
+            )?
+          else
+            _h.fail("request building failed")
+          end
 
       fun ref not_listening(listen: TCPListener ref) =>
         _h.fail_action("server listening")
@@ -75,33 +84,47 @@ class \nodoc\ iso _ConnectionClosedTest is UnitTest
       fun ref closed(listen: TCPListener ref) =>
         _h.log("TCP listener closed")
 
-      fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
-        _h.complete_action("server listen connected")
-        // server code
-        object iso is TCPConnectionNotify
-          fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
-            times: USize): Bool
-          =>
-            conn.close() // trigger the error condition
-            true
+        fun ref connected(
+          listen: TCPListener ref)
+          : TCPConnectionNotify iso^
+        =>
+          _h.complete_action("server listen connected")
+          // server code
+          object iso is TCPConnectionNotify
+            fun ref received(
+              conn: TCPConnection ref,
+              data: Array[U8] iso,
+              times: USize)
+              : Bool
+            =>
+              conn.close() // trigger the error condition
+              true
 
-          fun ref accepted(conn: TCPConnection ref) =>
-            _h.complete_action("server connection accepted")
-            _h.dispose_when_done(conn)
+            fun ref accepted(conn: TCPConnection ref) =>
+              _h.complete_action(
+                "server connection accepted")
+              _h.dispose_when_done(conn)
 
-          fun ref connect_failed(conn: TCPConnection ref) =>
-            _h.fail("connection failed")
+            fun ref connect_failed(
+              conn: TCPConnection ref)
+            =>
+              _h.fail("connection failed")
 
-          fun ref closed(conn: TCPConnection ref) =>
-            _h.complete_action("server connection closed")
-        end
-    end
+            fun ref closed(conn: TCPConnection ref) =>
+              _h.complete_action(
+                "server connection closed")
+          end
+      end
 
     let host = "127.0.0.1"
     let service = "0"
 
-    let listener = TCPListener.ip4(TCPListenAuth(h.env.root), consume notify,
-      host, service)
+    let listener =
+      TCPListener.ip4(
+        TCPListenAuth(h.env.root),
+        consume notify,
+        host,
+        service)
     h.dispose_when_done(listener)
 
 actor \nodoc\ _Connecter
@@ -121,15 +144,22 @@ actor \nodoc\ _Connecter
     _h.log("connecting to " + host + ":" + port')
     _h.complete_action("client trying to connect")
     try
-      let client = HTTPClient(
-        TCPConnectAuth(_h.env.root),
-        None
-        where keepalive_timeout_secs = U32(2)
-      )
-      let req = Payload.request("GET",
-        URL.build("http://" + host + ":" + port' + "/bla")?)
+      let client =
+        HTTPClient(
+          TCPConnectAuth(_h.env.root),
+          None
+          where keepalive_timeout_secs = U32(2)
+        )
+      let req =
+        Payload.request(
+          "GET",
+          URL.build(
+            "http://" + host + ":"
+              + port' + "/bla")?)
       req.add_chunk("CHUNK")
-      client(consume req, _ConnectFailedHandlerFactory(_h))?
+      client(
+        consume req,
+        _ConnectFailedHandlerFactory(_h))?
     else
       _h.fail("request building failed")
     end
@@ -146,7 +176,7 @@ class \nodoc\ val _ConnectFailedHandlerFactory is HandlerFactory
         _h.fail("failed by finishing")
         _h.complete(false)
       fun ref failed(reason: HTTPFailureReason) =>
-        match reason
+        match \exhaustive\ reason
         | AuthFailed =>
           _h.fail("failed with AuthFailed")
           _h.complete(false)
@@ -154,7 +184,8 @@ class \nodoc\ val _ConnectFailedHandlerFactory is HandlerFactory
           _h.fail("failed with ConnectionClosed")
           _h.complete(false)
         | ConnectFailed =>
-          _h.complete_action("client failed with ConnectFailed")
+          _h.complete_action(
+            "client failed with ConnectFailed")
         end
     end
 
@@ -169,44 +200,72 @@ class \nodoc\ iso _ConnectFailedTest is UnitTest
     h.expect_action("client trying to connect")
     h.expect_action("client failed with ConnectFailed")
 
-    let notify = object iso is TCPListenNotify
-      let _h: TestHelper = h
-      var host: String = ""
-      var port: String = ""
+    let notify =
+      object iso is TCPListenNotify
+        let _h: TestHelper = h
+        var host: String = ""
+        var port: String = ""
 
-      fun ref listening(listen: TCPListener ref) =>
-        _h.complete_action("server listening")
-        try
-          (host, port) = listen.local_address().name()?
-        else
-          _h.fail("unable to get port")
-        end
-        listen.close()
+        fun ref listening(listen: TCPListener ref) =>
+          _h.complete_action("server listening")
+          try
+            (host, port) =
+              listen.local_address().name()?
+          else
+            _h.fail("unable to get port")
+          end
+          listen.close()
 
-      fun ref not_listening(listen: TCPListener ref) =>
-        _h.fail_action("server listening")
+        fun ref not_listening(
+          listen: TCPListener ref)
+        =>
+          _h.fail_action("server listening")
 
-      fun ref closed(listen: TCPListener ref) =>
-        _h.complete_action("server closed")
-        let connecter = _Connecter(_h)
-        connecter.connect(host, port)
+        fun ref closed(listen: TCPListener ref) =>
+          _h.complete_action("server closed")
+          let connecter = _Connecter(_h)
+          connecter.connect(host, port)
 
-      fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
-        object iso is TCPConnectionNotify
-          fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
-            times: USize): Bool => true
-          fun ref accepted(conn: TCPConnection ref) => None
-          fun ref connect_failed(conn: TCPConnection ref) => None
-          fun ref closed(conn: TCPConnection ref) => None
-        end
-    end
+        fun ref connected(
+          listen: TCPListener ref)
+          : TCPConnectionNotify iso^
+        =>
+          object iso is TCPConnectionNotify
+            fun ref received(
+              conn: TCPConnection ref,
+              data: Array[U8] iso,
+              times: USize)
+              : Bool
+            =>
+              true
+
+            fun ref accepted(
+              conn: TCPConnection ref)
+            =>
+              None
+
+            fun ref connect_failed(
+              conn: TCPConnection ref)
+            =>
+              None
+
+            fun ref closed(
+              conn: TCPConnection ref)
+            =>
+              None
+          end
+      end
 
     let host = "127.0.0.1"
     let service = "0"
 
-    let listener = TCPListener.ip4(TCPListenAuth(h.env.root), consume notify, host, service)
+    let listener =
+      TCPListener.ip4(
+        TCPListenAuth(h.env.root),
+        consume notify,
+        host,
+        service)
     h.dispose_when_done(listener)
-
 
 primitive \nodoc\ _Paths
   fun join(paths: Array[String] box): String =>
@@ -218,6 +277,7 @@ primitive \nodoc\ _Paths
 
 class \nodoc\ val _SSLAuthFailedHandlerFactory is HandlerFactory
   let _h: TestHelper
+
   new val create(h: TestHelper) =>
     _h = h
 
@@ -242,35 +302,48 @@ class \nodoc\ iso _SSLAuthFailedTest is UnitTest
     // how the tests are called from the Makefile
     // which is not the nicest thing in the world
     let cwd = Path.cwd()
-    cert_path = FilePath(
-      FileAuth(h.env.root),
-      _Paths.join([
-        cwd
-        "http"
-        "test"
-        "cert.pem"])
-    )
+    cert_path =
+      FilePath(
+        FileAuth(h.env.root),
+        _Paths.join(
+          [ cwd
+            "http"
+            "test"
+            "cert.pem"
+          ]))
     if not (cert_path as FilePath).exists() then
-      h.log("cert path: " + (cert_path as FilePath).path + " does not exist!")
+      h.log(
+        "cert path: "
+          + (cert_path as FilePath).path
+          + " does not exist!")
       error
     end
-    key_path = FilePath(
-      FileAuth(h.env.root),
-      _Paths.join([
-        cwd
-        "http"
-        "test"
-        "key.pem"])
-    )
+    key_path =
+      FilePath(
+        FileAuth(h.env.root),
+        _Paths.join(
+          [ cwd
+            "http"
+            "test"
+            "key.pem"
+          ]))
     if not (key_path as FilePath).exists() then
-      h.log("key path: " + (key_path as FilePath).path + " does not exist!")
+      h.log(
+        "key path: "
+          + (key_path as FilePath).path
+          + " does not exist!")
       error
     end
     ifdef not windows then
-      ca_path = FilePath(FileAuth(h.env.root),
+      ca_path =
+        FilePath(
+          FileAuth(h.env.root),
           "/usr/share/ca-certificates/mozilla")
       if not (ca_path as FilePath).exists() then
-        h.log("ca path: " + (ca_path as FilePath).path + " does not exist!")
+        h.log(
+          "ca path: "
+            + (ca_path as FilePath).path
+            + " does not exist!")
         error
       end
     end
@@ -281,80 +354,123 @@ class \nodoc\ iso _SSLAuthFailedTest is UnitTest
     h.expect_action("server listening")
     h.expect_action("client failed with AuthFailed")
 
-    let notify = object iso is TCPListenNotify
-      let _h: TestHelper = h
-      var host: String = ""
-      var port: String = ""
+    let notify =
+      object iso is TCPListenNotify
+        let _h: TestHelper = h
+        var host: String = ""
+        var port: String = ""
 
-      fun ref listening(listen: TCPListener ref) =>
-        _h.complete_action("server listening")
-        _h.log("listening")
-        try
-          (host, port) = listen.local_address().name()?
+        fun ref listening(
+          listen: TCPListener ref)
+        =>
+          _h.complete_action("server listening")
+          _h.log("listening")
           try
-            let ssl_ctx: SSLContext val = recover
-              ifdef windows then
-                SSLContext.>set_authority(None, None)?
-              else
-                SSLContext.>set_authority(
-                  None
-                  where path = ca_path as FilePath)?
-              end
+            (host, port) =
+              listen.local_address().name()?
+            try
+              let ssl_ctx: SSLContext val =
+                recover
+                  ifdef windows then
+                    SSLContext
+                      .> set_authority(None, None)?
+                  else
+                    SSLContext
+                      .> set_authority(
+                        None
+                        where path =
+                          ca_path as FilePath)?
+                  end
+                end
+              let client =
+                HTTPClient(
+                  TCPConnectAuth(_h.env.root),
+                  ssl_ctx
+                  where keepalive_timeout_secs =
+                    U32(2)
+                )
+              let req =
+                Payload.request(
+                  "GET",
+                  URL.build(
+                    "https://" + host + ":"
+                      + port + "/bla")?)
+              req.add_chunk("CHUNK")
+              client(
+                consume req,
+                _SSLAuthFailedHandlerFactory(_h)
+              )?
+            else
+              _h.fail("request building failed")
             end
-            let client = HTTPClient(
-              TCPConnectAuth(_h.env.root),
-              ssl_ctx
-              where keepalive_timeout_secs = U32(2)
-            )
-            let req = Payload.request(
-              "GET",
-              URL.build("https://" + host + ":" + port  + "/bla")?)
-            req.add_chunk("CHUNK")
-            client(
-              consume req,
-              _SSLAuthFailedHandlerFactory(_h)
-            )?
           else
-            _h.fail("request building failed")
+            _h.fail("unable to get port")
           end
-        else
-          _h.fail("unable to get port")
-        end
 
-      fun ref not_listening(listen: TCPListener ref) =>
-        _h.fail_action("server listening")
-        _h.log("not_listening")
+        fun ref not_listening(
+          listen: TCPListener ref)
+        =>
+          _h.fail_action("server listening")
+          _h.log("not_listening")
 
-      fun ref closed(listen: TCPListener ref) =>
-        _h.log("TCP listener closed")
+        fun ref closed(listen: TCPListener ref) =>
+          _h.log("TCP listener closed")
 
-      fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ ? =>
-        _h.log("server listen connected.")
-        let tcp_notify =
-          object iso is TCPConnectionNotify
-            fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
-              times: USize): Bool
-            =>
-              _h.log("received on server")
-              conn.write(consume data)
-              true
-            fun ref accepted(conn: TCPConnection ref) =>
-              _h.log("accepted on server")
-            fun ref connect_failed(conn: TCPConnection ref) =>
-              _h.log("connect failed on server")
-            fun ref closed(conn: TCPConnection ref) =>
-              _h.log("closed on server")
-            fun ref auth_failed(conn: TCPConnection ref) =>
-              _h.log("auth failed on server")
-          end
-        let server_ssl_ctx = SSLContext.>set_cert(
-          cert_path as FilePath,
-          key_path as FilePath)?
-        SSLConnection(consume tcp_notify, server_ssl_ctx.server()?)
-    end
+        fun ref connected(
+          listen: TCPListener ref)
+          : TCPConnectionNotify iso^ ?
+        =>
+          _h.log("server listen connected.")
+          let tcp_notify =
+            object iso is TCPConnectionNotify
+              fun ref received(
+                conn: TCPConnection ref,
+                data: Array[U8] iso,
+                times: USize)
+                : Bool
+              =>
+                _h.log("received on server")
+                conn.write(consume data)
+                true
+
+              fun ref accepted(
+                conn: TCPConnection ref)
+              =>
+                _h.log("accepted on server")
+
+              fun ref connect_failed(
+                conn: TCPConnection ref)
+              =>
+                _h.log(
+                  "connect failed on server")
+
+              fun ref closed(
+                conn: TCPConnection ref)
+              =>
+                _h.log("closed on server")
+
+              fun ref auth_failed(
+                conn: TCPConnection ref)
+              =>
+                _h.log("auth failed on server")
+            end
+          let server_ssl_ctx =
+            SSLContext
+              .> set_cert(
+                cert_path as FilePath,
+                key_path as FilePath)?
+          SSLConnection(
+            consume tcp_notify,
+            server_ssl_ctx.server()?)
+      end
 
     let host = "127.0.0.1"
     let service = "0"
 
-    let listener = TCPListener.ip4(TCPListenAuth(h.env.root), consume notify, host, service)
+    let listener =
+      TCPListener.ip4(
+        TCPListenAuth(h.env.root),
+        consume notify,
+        host,
+        service)
     h.dispose_when_done(listener)

--- a/http/handler_factory.pony
+++ b/http/handler_factory.pony
@@ -11,6 +11,7 @@ primitive ConnectionClosed
   either from the other side (detectable when using TCP keepalive)
   or locally (e.g. due to an error).
   """
+
 primitive ConnectFailed
   """
   HTTP failure reason for when a connection could not be established.
@@ -18,10 +19,10 @@ primitive ConnectFailed
   This failure reason is only valid for HTTP client HTTPHandlers.
   """
 
-type HTTPFailureReason is (
-  AuthFailed |
-  ConnectionClosed |
-  ConnectFailed
+type HTTPFailureReason is
+  ( AuthFailed
+  | ConnectionClosed
+  | ConnectFailed
   )
   """
   HTTP failure reason reported to `HTTPHandler.failed()`.
@@ -73,14 +74,16 @@ interface HTTPHandler
 
   fun ref cancelled() =>
     """
-    Notification that transferring the payload has been cancelled locally,
-    e.g. by disposing the client, closing the server or manually cancelling a single request.
+    Notification that transferring the payload has been cancelled
+    locally, e.g. by disposing the client, closing the server or
+    manually cancelling a single request.
     """
 
   fun ref failed(reason: HTTPFailureReason) =>
     """
     Notification about failure to transfer the payload
-    (e.g. connection could not be established, authentication failed, connection was closed prematurely, ...)
+    (e.g. connection could not be established, authentication
+    failed, connection was closed prematurely).
     """
 
   fun ref throttled() =>

--- a/http/http_client.pony
+++ b/http/http_client.pony
@@ -23,20 +23,19 @@ class HTTPClient
     Create the context in which all HTTP sessions will originate.
 
     Parameters:
-    - keepalive_timeout_secs: Use TCP Keepalive and check if the other side is down
-                              every `keepalive_timeout_secs` seconds.
+    - keepalive_timeout_secs: Use TCP Keepalive and check if the
+      other side is down every `keepalive_timeout_secs` seconds.
     """
     _auth = auth
 
-    _sslctx = try
-      sslctx as SSLContext
-    else
-      recover
-        let newssl = SSLContext
-        newssl.set_client_verify(false)
-        newssl
+    _sslctx =
+      try
+        sslctx as SSLContext
+      else
+        recover
+          SSLContext .> set_client_verify(false)
         end
-    end
+      end
 
     _pipeline = pipeline
     _keepalive_timeout_secs = keepalive_timeout_secs
@@ -70,16 +69,6 @@ class HTTPClient
     end
     _sessions.clear()
 
-/*
-  fun ref cancel(request: Payload val) =>
-    """
-    Cancel a request.
-    """
-    match request.session
-    | let s _ClientConnection tag => s.cancel(request)
-    end
-*/
-
   fun ref _get_session(
     url: URL,
     handlermaker: HandlerFactory val)
@@ -99,11 +88,23 @@ class HTTPClient
       let session =
         match url.scheme
         | "http" =>
-          _ClientConnection(_auth, hs.host, hs.service,
-            None, _pipeline, _keepalive_timeout_secs, handlermaker)
+          _ClientConnection(
+            _auth,
+            hs.host,
+            hs.service,
+            None,
+            _pipeline,
+            _keepalive_timeout_secs,
+            handlermaker)
         | "https" =>
-          _ClientConnection(_auth, hs.host, hs.service,
-            _sslctx, _pipeline, _keepalive_timeout_secs, handlermaker)
+          _ClientConnection(
+            _auth,
+            hs.host,
+            hs.service,
+            _sslctx,
+            _pipeline,
+            _keepalive_timeout_secs,
+            handlermaker)
         else
           error
         end

--- a/http/http_parser.pony
+++ b/http/http_parser.pony
@@ -30,6 +30,9 @@ type _PayloadState is
   )
 
 primitive ParseError
+  """
+  Returned when the HTTP parser encounters invalid syntax.
+  """
 
 class HTTPParser
   """
@@ -99,11 +102,12 @@ class HTTPParser
     The parser is finished with the message headers so we can push it
     to the `HTTPSession`. The body may come later.
     """
-    let body_follows = match _payload.transfer_mode
+    let body_follows =
+      match _payload.transfer_mode
       | ChunkedTransfer => true
-    else
-      (_expected_length > 0)
-    end
+      else
+        (_expected_length > 0)
+      end
 
     // Set up `_payload` for the next message.
     let payload = _payload = Payload._empty(_client)
@@ -121,11 +125,12 @@ class HTTPParser
     _transfer_mode = OneshotTransfer
     _chunk_end = false
 
-    _state = if _client then
-      _ExpectResponse
-    else
-      _ExpectRequest
-    end
+    _state =
+      if _client then
+        _ExpectResponse
+      else
+        _ExpectRequest
+      end
 
   fun ref closed(buffer: Reader) =>
     """
@@ -206,37 +211,36 @@ class HTTPParser
     while true do
       // Try to get another line out of the available buffer.
       // If this fails it is not a syntax error; we just wait for more.
-      try
-        let line = buffer.line()?
-        if line.size() == 0 then
-          // An empty line marks the end of the headers. Set state
-          // appropriately.
-          _set_header_end()
-
-          // deliver for empty responses, chunked or streamed transfer
-          // accumulate the body in the Payload for OneshotTransfer
-          match _payload.transfer_mode
-          | OneshotTransfer if _state isnt _ExpectBody => _deliver()
-          | StreamTransfer =>                             _deliver()
-          | ChunkedTransfer =>                            _deliver()
-          end
-          parse(buffer)
+      let line =
+        try
+          buffer.line()?
         else
-          // A non-empty line *must* be a header. error if not.
-          try
-            _process_header(consume line)?
-          else
-            _state = _ExpectError
-            break
-          end
-        end // line-size check
-      else
-        // Failed to get a line. We stay in _ExpectHeader state.
-        return
-      end // try
-    end // looping over all headers in this buffer
+          // Failed to get a line. We stay in _ExpectHeader state.
+          return
+        end
 
-    // Breaking out of that loop means an error.
+      if line.size() == 0 then
+        // An empty line marks the end of the headers.
+        _set_header_end()
+
+        // deliver for empty responses, chunked or streamed transfer
+        // accumulate the body in the Payload for OneshotTransfer
+        match _payload.transfer_mode
+        | OneshotTransfer if _state isnt _ExpectBody => _deliver()
+        | StreamTransfer =>                             _deliver()
+        | ChunkedTransfer =>                            _deliver()
+        end
+        return parse(buffer)
+      end
+
+      // A non-empty line *must* be a header. error if not.
+      try
+        _process_header(consume line)?
+      else
+        _state = _ExpectError
+        return ParseError
+      end
+      end
     if _state is _ExpectError then ParseError end
 
   fun ref _process_header(line: String) ? =>
@@ -245,8 +249,9 @@ class HTTPParser
     or can't interpret the value.
     """
     let i = line.find(":")?
-    let key = line.substring(0, i)
-    key.>strip().lower_in_place()
+    let key_iso = line.substring(0, i)
+    key_iso .> strip().lower_in_place()
+    let key: String val = consume key_iso
     let value = line.substring(i + 1)
     value.strip()
     let value2: String val = consume value
@@ -283,7 +288,7 @@ class HTTPParser
 
     end // match certain headers
 
-    _payload(consume key) = value2
+    _payload(key) = value2
 
   fun ref _setauth(auth: String) =>
     """
@@ -317,10 +322,11 @@ class HTTPParser
       // If chunked mode or length>0 then some body data will follow.
       // In any case we can pass the completed `Payload` on to the
       // session for processing.
-      _state = match _payload.transfer_mode
-      | ChunkedTransfer =>
-        _ExpectChunkStart
-      else
+      _state =
+        match _payload.transfer_mode
+        | ChunkedTransfer =>
+          _ExpectChunkStart
+        else
         if _expected_length == 0 then
           _ExpectReady
         else
@@ -343,7 +349,7 @@ class HTTPParser
       let body = recover val consume bytes end
       _expected_length = _expected_length - usable
       // in streaming mode we already have a new unrelated payload in _payload
-      // so we need to keep track of the current transfer-mode via _transfer_mode
+      // so we track the current transfer-mode via _transfer_mode
       match _transfer_mode
       | OneshotTransfer =>
         // in oneshot transfer we actually fill the body of the payload
@@ -372,20 +378,22 @@ class HTTPParser
     terminated by CRLF. An explicit length of zero marks the end of
     the entire chunked message body.
     """
-    let line = try
-      buffer.line()?
-    else
-      return ParseError
-    end
+    let line =
+      try
+        buffer.line()?
+      else
+        return ParseError
+      end
 
     if line.size() > 0
     then
       // This should be the length of the next chunk.
-      _expected_length = try
-        line.read_int[USize](0, 16)?._1
-      else
-        return ParseError
-      end
+      _expected_length =
+        try
+          line.read_int[USize](0, 16)?._1
+        else
+          return ParseError
+        end
       // A chunk explicitly of length zero marks the end of the body.
       if _expected_length > 0 then
         _state = _ExpectChunk
@@ -422,7 +430,7 @@ class HTTPParser
       if _expected_length == 0 then
         _state = _ExpectChunkEnd
         parse(buffer)
-        end
+      end
     end
 
   fun ref _parse_chunk_end(buffer: Reader) =>

--- a/http/mime_types.pony
+++ b/http/mime_types.pony
@@ -1,9 +1,9 @@
-primitive MimeTypes
+primitive MIMETypes
   """
   Provide mapping from file names to MIME types.
   TODO load from /etc/mime.types
   """
-  
+
   fun apply(name: String): String val^ =>
     """
     Mapping is based on the file type, following the last period in the name.

--- a/http/payload.pony
+++ b/http/payload.pony
@@ -4,8 +4,19 @@ use "format"
 use "buffered"
 
 primitive ChunkedTransfer
+  """
+  Transfer the body in chunks with no predetermined total length.
+  """
+
 primitive StreamTransfer
+  """
+  Transfer the body as a stream with a known Content-Length.
+  """
+
 primitive OneshotTransfer
+  """
+  Transfer the entire body at once, determining the length at send time.
+  """
 
 type TransferMode is (ChunkedTransfer | StreamTransfer | OneshotTransfer)
 
@@ -75,14 +86,12 @@ class trn Payload
   """
   var proto: String = "HTTP/1.1"
     """The HTTP protocol string"""
-
   var status: U16
     """
     Internal representation of the response [Status](http-Status).
 
     Will be `0` for HTTP requests.
     """
-
   var method: String
     """
     The HTTP Method.
@@ -92,7 +101,6 @@ class trn Payload
     For HTTP responses this will be the status string,
     for a `200` status this will be `200 OK`, for `404`, `404 Not Found` etc..
     """
-
   var url: URL
     """
     The HTTP request [URL](http-URL).
@@ -113,7 +121,6 @@ class trn Payload
     how the request is transferred.
     """
   var session: (HTTPSession | None) = None
-
   embed _headers: Map[String, String] = _headers.create()
   embed _body: Array[ByteSeq val] = _body.create()
   let _response: Bool
@@ -200,7 +207,7 @@ class trn Payload
     transfer. Not calling this function at all will
     use Oneshot transfer.
     """
-    match bytecount
+    match \exhaustive\ bytecount
     | None  =>
       transfer_mode = ChunkedTransfer
       _headers("Transfer-Encoding") = "chunked"
@@ -217,9 +224,10 @@ class trn Payload
     Set any header. If we've already received the header, append the value as a
     comma separated list, as per RFC 2616 section 4.2.
     """
-    _headers.upsert(key.lower(),
+    _headers.upsert(
+      key.lower(),
       value,
-      {(current, provided) => current + "," + provided})
+      {(current, provided) => current + "," + provided })
     this
 
   fun headers(): this->Map[String, String] =>

--- a/http/status.pony
+++ b/http/status.pony
@@ -1,146 +1,343 @@
 trait val Status
+  """
+  An HTTP response status code with its reason phrase.
+  """
   fun apply(): U16
+    """
+    The numeric status code.
+    """
+
   fun string(): String
+    """
+    The status code and reason phrase, e.g. `"200 OK"`.
+    """
 
 primitive StatusContinue is Status
+  """
+  100: the server received the request headers and the client should send
+  the body.
+  """
   fun apply(): U16 => 100
   fun string(): String => "100 Continue"
+
 primitive StatusSwitchingProtocols is Status
+  """
+  101: the server is switching to the protocol requested by the client.
+  """
   fun apply(): U16 => 101
   fun string(): String => "101 Switching Protocols"
 
 primitive StatusOK is Status
+  """
+  200: the request succeeded.
+  """
   fun apply(): U16 => 200
   fun string(): String => "200 OK"
+
 primitive StatusCreated is Status
+  """
+  201: the request succeeded and a new resource was created.
+  """
   fun apply(): U16 => 201
   fun string(): String => "201 Created"
+
 primitive StatusAccepted is Status
+  """
+  202: the request was accepted for processing but processing is not
+  complete.
+  """
   fun apply(): U16 => 202
   fun string(): String => "202 Accepted"
+
 primitive StatusNonAuthoritativeInfo is Status
+  """
+  203: the response contains modified metadata from a third-party copy.
+  """
   fun apply(): U16 => 203
   fun string(): String => "203 Non-Authoritative Information"
+
 primitive StatusNoContent is Status
+  """
+  204: the request succeeded but there is no content to send.
+  """
   fun apply(): U16 => 204
   fun string(): String => "204 No Content"
+
 primitive StatusResetContent is Status
+  """
+  205: the client should reset the document view.
+  """
   fun apply(): U16 => 205
   fun string(): String => "205 Reset Content"
+
 primitive StatusPartialContent is Status
+  """
+  206: the server is delivering part of the resource due to a range
+  request.
+  """
   fun apply(): U16 => 206
   fun string(): String => "206 Partial Content"
 
 primitive StatusMultipleChoices is Status
+  """
+  300: the request has more than one possible response.
+  """
   fun apply(): U16 => 300
   fun string(): String => "300 Multiple Choices"
+
 primitive StatusMovedPermanently is Status
+  """
+  301: the resource has been permanently moved to a new URL.
+  """
   fun apply(): U16 => 301
   fun string(): String => "301 Moved Permanently"
+
 primitive StatusFound is Status
+  """
+  302: the resource is temporarily at a different URL.
+  """
   fun apply(): U16 => 302
   fun string(): String => "302 Found"
+
 primitive StatusSeeOther is Status
+  """
+  303: the response to the request is at another URL, retrieved with GET.
+  """
   fun apply(): U16 => 303
   fun string(): String => "303 See Other"
+
 primitive StatusNotModified is Status
+  """
+  304: the resource has not been modified since the version specified by
+  the request headers.
+  """
   fun apply(): U16 => 304
   fun string(): String => "304 Not Modified"
+
 primitive StatusUseProxy is Status
+  """
+  305: the requested resource must be accessed through the specified
+  proxy.
+  """
   fun apply(): U16 => 305
   fun string(): String => "305 Use Proxy"
+
 primitive StatusTemporaryRedirect is Status
+  """
+  307: the resource is temporarily at a different URL; the client should
+  use the same method.
+  """
   fun apply(): U16 => 307
   fun string(): String => "307 Temporary Redirect"
 
 primitive StatusBadRequest is Status
+  """
+  400: the server cannot process the request due to a client error.
+  """
   fun apply(): U16 => 400
   fun string(): String => "400 Bad Request"
+
 primitive StatusUnauthorized is Status
+  """
+  401: the request requires authentication.
+  """
   fun apply(): U16 => 401
   fun string(): String => "401 Unauthorized"
+
 primitive StatusPaymentRequired is Status
+  """
+  402: reserved for future use.
+  """
   fun apply(): U16 => 402
   fun string(): String => "402 Payment Required"
+
 primitive StatusForbidden is Status
+  """
+  403: the server understood the request but refuses to authorize it.
+  """
   fun apply(): U16 => 403
   fun string(): String => "403 Forbidden"
+
 primitive StatusNotFound is Status
+  """
+  404: the server cannot find the requested resource.
+  """
   fun apply(): U16 => 404
   fun string(): String => "404 Not Found"
+
 primitive StatusMethodNotAllowed is Status
+  """
+  405: the request method is not supported for the target resource.
+  """
   fun apply(): U16 => 405
   fun string(): String => "405 Method Not Allowed"
+
 primitive StatusNotAcceptable is Status
+  """
+  406: the server cannot produce a response matching the Accept headers.
+  """
   fun apply(): U16 => 406
   fun string(): String => "406 Not Acceptable"
+
 primitive StatusProxyAuthRequired is Status
+  """
+  407: the client must authenticate with the proxy.
+  """
   fun apply(): U16 => 407
   fun string(): String => "407 Proxy Authentication Required"
+
 primitive StatusRequestTimeout is Status
+  """
+  408: the server timed out waiting for the request.
+  """
   fun apply(): U16 => 408
   fun string(): String => "408 Request Timeout"
+
 primitive StatusConflict is Status
+  """
+  409: the request conflicts with the current state of the resource.
+  """
   fun apply(): U16 => 409
   fun string(): String => "409 Conflict"
+
 primitive StatusGone is Status
+  """
+  410: the resource is no longer available and has no forwarding address.
+  """
   fun apply(): U16 => 410
   fun string(): String => "410 Gone"
+
 primitive StatusLengthRequired is Status
+  """
+  411: the server requires a Content-Length header.
+  """
   fun apply(): U16 => 411
   fun string(): String => "411 Length Required"
+
 primitive StatusPreconditionFailed is Status
+  """
+  412: a precondition in the request headers evaluated to false.
+  """
   fun apply(): U16 => 412
   fun string(): String => "412 Precondition Failed"
+
 primitive StatusRequestEntityTooLarge is Status
+  """
+  413: the request payload exceeds the server's size limit.
+  """
   fun apply(): U16 => 413
   fun string(): String => "413 Request Entity Too Large"
+
 primitive StatusRequestURITooLong is Status
+  """
+  414: the request URI exceeds the server's length limit.
+  """
   fun apply(): U16 => 414
   fun string(): String => "414 Request URI Too Long"
+
 primitive StatusUnsupportedMediaType is Status
+  """
+  415: the request payload format is not supported.
+  """
   fun apply(): U16 => 415
   fun string(): String => "415 Unsupported Media Type"
+
 primitive StatusRequestedRangeNotSatisfiable is Status
+  """
+  416: the range specified in the request cannot be fulfilled.
+  """
   fun apply(): U16 => 416
   fun string(): String => "416 Requested Range Not Satisfiable"
+
 primitive StatusExpectationFailed is Status
+  """
+  417: the server cannot meet the requirements of the Expect header.
+  """
   fun apply(): U16 => 417
   fun string(): String => "417 Expectation Failed"
+
 primitive StatusTeapot is Status
+  """
+  418: the server refuses to brew coffee because it is a teapot
+  (RFC 2324).
+  """
   fun apply(): U16 => 418
   fun string(): String => "418 I'm a teapot"
+
 primitive StatusPreconditionRequired is Status
+  """
+  428: the server requires the request to be conditional.
+  """
   fun apply(): U16 => 428
   fun string(): String => "428 Precondition Required"
+
 primitive StatusTooManyRequests is Status
+  """
+  429: the client has sent too many requests in a given time period.
+  """
   fun apply(): U16 => 429
   fun string(): String => "429 Too Many Requests"
+
 primitive StatusRequestHeaderFieldsTooLarge is Status
+  """
+  431: the request headers exceed the server's size limit.
+  """
   fun apply(): U16 => 431
   fun string(): String => "431 Request Header Fields Too Large"
+
 primitive StatusUnavailableForLegalReasons is Status
+  """
+  451: the resource is unavailable due to a legal demand.
+  """
   fun apply(): U16 => 451
   fun string(): String => "451 Unavailable For Legal Reasons"
 
 primitive StatusInternalServerError is Status
+  """
+  500: the server encountered an unexpected condition.
+  """
   fun apply(): U16 => 500
   fun string(): String => "500 Internal Server Error"
+
 primitive StatusNotImplemented is Status
+  """
+  501: the server does not support the request method.
+  """
   fun apply(): U16 => 501
   fun string(): String => "501 Not Implemented"
+
 primitive StatusBadGateway is Status
+  """
+  502: the server received an invalid response from an upstream server.
+  """
   fun apply(): U16 => 502
   fun string(): String => "502 Bad Gateway"
+
 primitive StatusServiceUnavailable is Status
+  """
+  503: the server is temporarily unable to handle the request.
+  """
   fun apply(): U16 => 503
   fun string(): String => "503 Service Unavailable"
+
 primitive StatusGatewayTimeout is Status
+  """
+  504: the server did not receive a timely response from an upstream
+  server.
+  """
   fun apply(): U16 => 504
   fun string(): String => "504 Gateway Timeout"
+
 primitive StatusHTTPVersionNotSupported is Status
+  """
+  505: the server does not support the HTTP version used in the request.
+  """
   fun apply(): U16 => 505
   fun string(): String => "505 HTTP Version Not Supported"
+
 primitive StatusNetworkAuthenticationRequired is Status
+  """
+  511: the client must authenticate to gain network access.
+  """
   fun apply(): U16 => 511
   fun string(): String => "511 Network Authentication Required"

--- a/http/url.pony
+++ b/http/url.pony
@@ -11,7 +11,6 @@ class val URL
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.1).
     """
-
   var user: String = ""
     """
     URL user as part of the URLs authority component:
@@ -24,7 +23,6 @@ class val URL
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.2.1).
     """
-
   var password: String = ""
     """
     URL password as part of the URLs authority component:
@@ -37,7 +35,6 @@ class val URL
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.2.1).
     """
-
   var host: String = ""
     """
     URL host as part of the URLs authority component:
@@ -50,7 +47,6 @@ class val URL
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.2.2).
     """
-
   var port: U16 = 0
     """
     URL port as part of the URLs authority component:
@@ -63,7 +59,6 @@ class val URL
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.2.3).
     """
-
   var path: String = ""
     """
     URL path component.
@@ -72,21 +67,21 @@ class val URL
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3).
     """
-
   var query: String = ""
     """
     URL query component.
 
-    If the URL does not provide a query component, this will be the empty string.
+    If the URL does not provide a query component, this will be the
+    empty string.
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.4).
     """
-
   var fragment: String = ""
     """
     Url fragment identifier component.
 
-    If the URL does not provide a fragment identifier component, this will be the empty string.
+    If the URL does not provide a fragment identifier component, this
+    will be the empty string.
 
     See also [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.5).
     """

--- a/http/url_encode.pony
+++ b/http/url_encode.pony
@@ -1,9 +1,32 @@
 primitive URLPartUser
+  """
+  The user component of a URL.
+  """
+
 primitive URLPartPassword
+  """
+  The password component of a URL.
+  """
+
 primitive URLPartHost
+  """
+  The host component of a URL.
+  """
+
 primitive URLPartPath
+  """
+  The path component of a URL.
+  """
+
 primitive URLPartQuery
+  """
+  The query component of a URL.
+  """
+
 primitive URLPartFragment
+  """
+  The fragment component of a URL.
+  """
 
 type URLPart is
   ( URLPartUser
@@ -13,7 +36,6 @@ type URLPart is
   | URLPartQuery
   | URLPartFragment
   )
-
 
 primitive URLEncode
   """
@@ -102,7 +124,7 @@ primitive URLEncode
 
       while i < scheme.size() do
         let c = scheme(i)?
-        
+
         if
           ((c < 'a') or (c > 'z'))
             and ((c < 'A') or (c > 'Z'))
@@ -113,7 +135,7 @@ primitive URLEncode
         then
           return false
         end
-        
+
         i = i + 1
       end
     end
@@ -138,7 +160,7 @@ primitive URLEncode
 
       while i < from.size() do
         let c = from(i)?
-        
+
         if c == '%' then
           // Character is encoded.
           // _unhex() will throw on bad / missing hex digit.
@@ -183,7 +205,7 @@ primitive URLEncode
     else
       false
     end
-    
+
   fun _normal_decode(value: U8, part: URLPart): Bool =>
     """
     Determine whether the given character should be decoded to give normal
@@ -246,7 +268,7 @@ primitive URLEncode
       then
         error
       end
-        
+
       i = i + 1
     end
 


### PR DESCRIPTION
Add pony-lint CI workflow and Makefile target. Fix all lint style
errors across the codebase.

File renames:
- `mimetypes.pony` → `mime_types.pony` (`MimeTypes` → `MIMETypes`)
- `http_handler.pony` → `handler_factory.pony`

Also removes commented-out dead code (`cancel` method in `HTTPClient`).
